### PR TITLE
Remove Search Overview

### DIFF
--- a/application.json
+++ b/application.json
@@ -189,10 +189,6 @@
       ],
       "dashboards": [
         {
-          "name": "Overview",
-          "lookmlID": "google_adwords::account_performance"
-        },
-        {
           "name": "Campaigns",
           "lookmlID": "google_adwords::campaign_performance_overview"
         },


### PR DESCRIPTION
It is the App Overview dashboard, no need to duplicate.